### PR TITLE
Fixes #82, fixes #81, fixes #80

### DIFF
--- a/MSOE.MediaComplete.Lib/Background/Queue.cs
+++ b/MSOE.MediaComplete.Lib/Background/Queue.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using MSOE.MediaComplete.Lib.Background;
 using Sys = System.Threading.Tasks;
 
 namespace MSOE.MediaComplete.Lib.Background
@@ -8,23 +10,14 @@ namespace MSOE.MediaComplete.Lib.Background
     /// Class to manage long-running background operations. Will run tasks in parallel where possible, 
     /// and block otherwise, based on the implemenatation of the tasks passed in. This class is a singleton.
     /// </summary>
-    public class Queue
+    public class Queue : IQueue
     {
-        /// <summary>
-        /// The singleton instance available to callers.
-        /// </summary>
-        public static Queue Inst { get; private set; }
-
         /// <summary>
         /// Private constructor, creates an empty queue.
         /// </summary>
-        private Queue()
+        public Queue()
         {
             _tasks = new List<List<Task>>();
-        }
-        static Queue()
-        {
-            Inst = new Queue();
         }
 
         #region Privates
@@ -113,4 +106,9 @@ namespace MSOE.MediaComplete.Lib.Background
                 t.Message, t.Icon, t.Id, _sessionCount, (t.PercentComplete * 100).ToString("N1"));
         }
     }
+}
+
+public interface IQueue
+{
+    void Add(Task newTask);
 }

--- a/MSOE.MediaComplete.Lib/Dependency.cs
+++ b/MSOE.MediaComplete.Lib/Dependency.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Autofac;
+using Autofac.Core;
+using MSOE.MediaComplete.Lib.Files;
+using MSOE.MediaComplete.Lib.Import;
+using MSOE.MediaComplete.Lib.Metadata;
+using MSOE.MediaComplete.Lib.Sorting;
+
+namespace MSOE.MediaComplete.Lib
+{
+    public static class Dependency
+    {
+        private static IContainer _afContainer;
+        
+        public static async void BuildAsync()
+        {
+            var builder = new ContainerBuilder();
+            var fileManager = FileManager.Instance;
+            fileManager.Initialize(SettingWrapper.MusicDir);
+            builder.RegisterInstance(fileManager).ExternallyOwned().As<IFileManager>();
+            builder.RegisterType<FfmpegAudioReader>().As<IAudioReader>();
+            builder.RegisterType<DoresoIdentifier>().As<IAudioIdentifier>();
+            builder.RegisterInstance(await SpotifyMetadataRetriever.GetInstanceAsync()).ExternallyOwned().As<IMetadataRetriever>();
+            builder.RegisterType<Identifier>().WithParameters(new[]
+            {
+                new ResolvedParameter((pi, c) => pi.ParameterType == typeof(IAudioReader), (pi, c) => c.Resolve<IAudioReader>()),
+                new ResolvedParameter((pi, c) => pi.ParameterType == typeof(IAudioIdentifier), (pi, c) => c.Resolve<IAudioIdentifier>()),
+                new ResolvedParameter((pi, c) => pi.ParameterType == typeof(IMetadataRetriever), (pi, c) => c.Resolve<IMetadataRetriever>()),
+                new ResolvedParameter((pi, c) => pi.ParameterType == typeof(IFileManager), (pi, c) => c.Resolve<IFileManager>())
+            });
+            builder.RegisterType<Sorter>().WithParameters(new[]
+            {
+                new ResolvedParameter((pi, c) => pi.ParameterType == typeof(IFileManager), (pi, c) => c.Resolve<IFileManager>())
+            });
+            builder.RegisterType<Importer>().WithParameters(new[]
+            {
+                new ResolvedParameter((pi, c) => pi.ParameterType == typeof(IFileManager), (pi, c) => c.Resolve<IFileManager>())
+            });
+            _afContainer = builder.Build();
+        }
+
+        public static T Resolve<T>()
+        {
+            return _afContainer.Resolve<T>();
+        }
+
+        public static ILifetimeScope BeginLifetimeScope()
+        {
+            return _afContainer.BeginLifetimeScope();
+        }
+    }
+}

--- a/MSOE.MediaComplete.Lib/Dependency.cs
+++ b/MSOE.MediaComplete.Lib/Dependency.cs
@@ -52,12 +52,20 @@ namespace MSOE.MediaComplete.Lib
             _afContainer = builder.Build();
         }
 
+        /// <summary>
+        /// Used to get an instance of a dependency that will/should persist for the lifetime of the application. e.g. single instance classes
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
         public static T Resolve<T>()
         {
             if(_afContainer == null) BuildAsync();
             return _afContainer.Resolve<T>();
         }
-
+        /// <summary>
+        /// Used to get an instance of a dependency with a lifetime. i.e. something that will end during the lifetime of the application
+        /// </summary>
+        /// <returns></returns>
         public static ILifetimeScope BeginLifetimeScope()
         {
             return _afContainer.BeginLifetimeScope();

--- a/MSOE.MediaComplete.Lib/Dependency.cs
+++ b/MSOE.MediaComplete.Lib/Dependency.cs
@@ -1,5 +1,6 @@
 ﻿using Autofac;
 using Autofac.Core;
+using MSOE.MediaComplete.Lib.Background;
 using MSOE.MediaComplete.Lib.Files;
 using MSOE.MediaComplete.Lib.Import;
 using MSOE.MediaComplete.Lib.Metadata;
@@ -46,6 +47,8 @@ namespace MSOE.MediaComplete.Lib
             {
                 new ResolvedParameter((pi, c) => pi.ParameterType == typeof(IFileManager), (pi, c) => c.Resolve<IFileManager>())
             });
+            var queue = new Queue();
+            builder.RegisterInstance(queue).As<IQueue>();
             _afContainer = builder.Build();
         }
 

--- a/MSOE.MediaComplete.Lib/Dependency.cs
+++ b/MSOE.MediaComplete.Lib/Dependency.cs
@@ -4,6 +4,7 @@ using MSOE.MediaComplete.Lib.Files;
 using MSOE.MediaComplete.Lib.Import;
 using MSOE.MediaComplete.Lib.Metadata;
 using MSOE.MediaComplete.Lib.Playing;
+using MSOE.MediaComplete.Lib.Playlists;
 using MSOE.MediaComplete.Lib.Sorting;
 
 namespace MSOE.MediaComplete.Lib
@@ -40,6 +41,11 @@ namespace MSOE.MediaComplete.Lib
             builder.RegisterType<NAudioWrapper>().As<INAudioWrapper>();
             var polling = new Polling();
             builder.RegisterInstance(polling).As<IPolling>();
+
+            builder.RegisterType<PlaylistServiceImpl>().WithParameters(new[]
+            {
+                new ResolvedParameter((pi, c) => pi.ParameterType == typeof(IFileManager), (pi, c) => c.Resolve<IFileManager>())
+            });
             _afContainer = builder.Build();
         }
 

--- a/MSOE.MediaComplete.Lib/Import/Importer.cs
+++ b/MSOE.MediaComplete.Lib/Import/Importer.cs
@@ -30,13 +30,13 @@ namespace MSOE.MediaComplete.Lib.Import
         /// <summary>
         /// Constructs an Importer with the given library home directory.
         /// </summary>
-        /// <param name="fileManagers">FileManager used for dependency injection</param>
+        /// <param name="fileManager"></param>
         /// <param name="files"></param>
         /// <param name="isMove"></param>
-        public Importer(IFileManager fileManagers, IEnumerable<SongPath> files, bool isMove)
+        public Importer(IFileManager fileManager, IEnumerable<SongPath> files, bool isMove)
         {
-            if(fileManagers == null || files == null) throw new ArgumentNullException();
-            _fileManager = fileManagers;
+            if(fileManager == null || files == null) throw new ArgumentNullException();
+            _fileManager = fileManager;
             _isMove = isMove;
             if (files.Any(f => f.HasParent(SettingWrapper.MusicDir)))
             {

--- a/MSOE.MediaComplete.Lib/MSOE.MediaComplete.Lib.csproj
+++ b/MSOE.MediaComplete.Lib/MSOE.MediaComplete.Lib.csproj
@@ -41,6 +41,9 @@
     <OutputPath>bin\x86\Release\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Autofac">
+      <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
+    </Reference>
     <Reference Include="log4net">
       <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
     </Reference>
@@ -86,6 +89,7 @@
     <Compile Include="Background\Task.cs" />
     <Compile Include="Background\Queue.cs" />
     <Compile Include="Background\TaskAdder.cs" />
+    <Compile Include="Dependency.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Logging\Logger.cs" />
     <Compile Include="Files\AbstractSong.cs" />

--- a/MSOE.MediaComplete.Lib/Playing/NowPlaying.cs
+++ b/MSOE.MediaComplete.Lib/Playing/NowPlaying.cs
@@ -41,7 +41,7 @@ namespace MSOE.MediaComplete.Lib.Playing
         {
             get
             {
-                var pl = new Playlist(new FakeM3U());
+                var pl = new Playlist(Dependency.Resolve<PlaylistServiceImpl>(), new FakeM3U());
                 pl.Songs.AddRange(_songs);
                 return pl;
             }

--- a/MSOE.MediaComplete.Lib/Playing/Player.cs
+++ b/MSOE.MediaComplete.Lib/Playing/Player.cs
@@ -27,7 +27,7 @@ namespace MSOE.MediaComplete.Lib.Playing
         /// </summary>
         public static Player Instance
         {
-            get { return _instance ?? (_instance = new Player(new NAudioWrapper(), Dependency.Resolve<IFileManager>())); }
+            get { return _instance ?? (_instance = new Player(Dependency.Resolve<INAudioWrapper>(), Dependency.Resolve<IFileManager>())); }
         }
 
         /// <summary>

--- a/MSOE.MediaComplete.Lib/Playing/Player.cs
+++ b/MSOE.MediaComplete.Lib/Playing/Player.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Autofac;
 using MSOE.MediaComplete.Lib.Files;
 using NAudio.Wave;
 using TagLib;
@@ -26,7 +27,7 @@ namespace MSOE.MediaComplete.Lib.Playing
         /// </summary>
         public static Player Instance
         {
-            get { return _instance ?? (_instance = new Player(new NAudioWrapper(), FileManager.Instance)); }
+            get { return _instance ?? (_instance = new Player(new NAudioWrapper(), Dependency.Resolve<IFileManager>())); }
         }
 
         /// <summary>

--- a/MSOE.MediaComplete.Lib/Playlists/Playlist.cs
+++ b/MSOE.MediaComplete.Lib/Playlists/Playlist.cs
@@ -13,6 +13,7 @@ namespace MSOE.MediaComplete.Lib.Playlists
     public class Playlist
     {
         private readonly IM3UFile _file;
+        private readonly IPlaylistService _service;
 
         public List<AbstractSong> Songs { get; private set; }
         
@@ -25,11 +26,13 @@ namespace MSOE.MediaComplete.Lib.Playlists
         /// <summary>
         /// Creates a new playlist based on an underlying M3U file.
         /// </summary>
+        /// <param name="service"></param>
         /// <param name="file">The M3U file</param>
-        public Playlist(IM3UFile file)
+        public Playlist(IPlaylistService service, IM3UFile file)
         {
+            _service = service;
             _file = file;
-            Songs = _file.Files.Select(PlaylistService.Create).ToList();
+            Songs = _file.Files.Select(service.Create).ToList();
         }
 
         /// <summary>
@@ -42,7 +45,7 @@ namespace MSOE.MediaComplete.Lib.Playlists
             {
                 try
                 {
-                    _file.Files.Add(PlaylistService.ToMediaItem(song as LocalSong));
+                    _file.Files.Add(_service.ToMediaItem(song as LocalSong));
                 }
                 catch (FileNotFoundException e)
                 {

--- a/MSOE.MediaComplete.Lib/Playlists/PlaylistService.cs
+++ b/MSOE.MediaComplete.Lib/Playlists/PlaylistService.cs
@@ -169,7 +169,7 @@ namespace MSOE.MediaComplete.Lib.Playlists
                 GetDirectoryInfo()
                     .EnumerateFiles(Constants.Wildcard, SearchOption.AllDirectories)
                     .Where(f => Constants.PlaylistFileExtensions.Any(e => f.Extension.Equals(e)));
-            var z = y.Select(f => new Playlist(new M3UFile(f)));
+            var z = y.Select(f => new Playlist(Dependency.Resolve<IPlaylistService>(), new M3UFile(f)));
             return z;
 
         }
@@ -196,7 +196,7 @@ namespace MSOE.MediaComplete.Lib.Playlists
                 .FirstOrDefault(f => Path.GetFileNameWithoutExtension(f.Name).Equals(title) &&
                                      Constants.PlaylistFileExtensions.Any(e => f.Extension.Equals(e)));
 
-            return file == null ? null : new Playlist(new M3UFile(file));
+            return file == null ? null : new Playlist(Dependency.Resolve<PlaylistServiceImpl>(), new M3UFile(file));
         }
 
         /// <summary>
@@ -211,7 +211,7 @@ namespace MSOE.MediaComplete.Lib.Playlists
             {
                 throw new IOException("A playlist by that title already exists.");
             }
-            return new Playlist(new M3UFile(new FileInfo(GetDirectoryInfo().FullName + Path.DirectorySeparatorChar + title + DefaultExtension)));
+            return new Playlist(Dependency.Resolve<PlaylistServiceImpl>(), new M3UFile(new FileInfo(GetDirectoryInfo().FullName + Path.DirectorySeparatorChar + title + DefaultExtension)));
         }
 
         /// <summary>

--- a/MSOE.MediaComplete.Lib/Playlists/PlaylistService.cs
+++ b/MSOE.MediaComplete.Lib/Playlists/PlaylistService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Autofac;
 using M3U.NET;
 using MSOE.MediaComplete.Lib.Files;
 
@@ -19,7 +20,7 @@ namespace MSOE.MediaComplete.Lib.Playlists
         /// </summary>
         public const string PlaylistDefaultTitle = "New playlist";
 
-        private static IPlaylistService _service = new PlaylistServiceImpl(FileManager.Instance);
+        private static IPlaylistService _service = new PlaylistServiceImpl(Dependency.Resolve<IFileManager>());
 
         /// <summary>
         /// Provides a way to substitute the implementation for playlist operations. 

--- a/MSOE.MediaComplete.Lib/Polling.cs
+++ b/MSOE.MediaComplete.Lib/Polling.cs
@@ -11,19 +11,18 @@ namespace MSOE.MediaComplete.Lib
     /// <summary>
     /// Class used to set up a timed interval to poll a directory for files, and trigger an event when they 
     /// </summary>
-    public class Polling
+    public class Polling : IPolling
     {
         private readonly Timer _timer;
         public double TimeInMinutes { get; set; }
-        private static Polling _instance;
 
         public delegate void InboxFilesHandler(IEnumerable<SongPath> files);
         public static event InboxFilesHandler InboxFilesDetected = delegate {};
 
         /// <summary>
-        /// private constructor to build out a timer object and subscribe to its events
+        /// constructor to build out a timer object and subscribe to its events
         /// </summary>
-        private Polling()
+        public Polling()
         {
             _timer = new Timer();
             _timer.Elapsed += OnTimerFinished;
@@ -44,15 +43,7 @@ namespace MSOE.MediaComplete.Lib
             _timer.Interval = timeInMilliseconds;
             _timer.Enabled = true;
         }
-
-        /// <summary>
-        /// gets the instance of the singleton Polling
-        /// </summary>
-        public static Polling Instance
-        {
-            get { return _instance ?? (_instance = new Polling()); }
-        }
-
+        
         /// <summary>
         /// sets up the new polling interval and change of directory to watch
         /// </summary>
@@ -92,5 +83,13 @@ namespace MSOE.MediaComplete.Lib
                 InboxFilesDetected(fileInfos);
             }
         }
+    }
+
+    public interface IPolling
+    {
+         void Reset();
+         void OnSettingChanged();
+         void Start();
+         double TimeInMinutes { get; set; }
     }
 }

--- a/MSOE.MediaComplete.Test/Background/QueueTest.cs
+++ b/MSOE.MediaComplete.Test/Background/QueueTest.cs
@@ -17,7 +17,8 @@ namespace MSOE.MediaComplete.Test.Background
         public void Add_Task_CallsResolveConflicts()
         {
             var mock = new MockTask();
-            Queue.Inst.Add(mock);
+            var queue = new Queue();
+            queue.Add(mock);
 
             SpinWait.SpinUntil(() => mock.DoCalled);
         }
@@ -26,10 +27,11 @@ namespace MSOE.MediaComplete.Test.Background
         public void Add_QueueAlreadyRunning_NewTaskRuns()
         {
             var longMock = new MockTask(Delay);
-            Queue.Inst.Add(longMock);
+            var queue = new Queue();
+            queue.Add(longMock);
 
             var secondMock = new MockTask();
-            Queue.Inst.Add(secondMock);
+            queue.Add(secondMock);
 
             Assert.IsFalse(secondMock.DoCalled, "Second mock started too early!");
 

--- a/MSOE.MediaComplete.Test/Playlists/PlaylistTest.cs
+++ b/MSOE.MediaComplete.Test/Playlists/PlaylistTest.cs
@@ -15,7 +15,14 @@ namespace MSOE.MediaComplete.Test.Playlists
         {
             const string testTitle = "Test title";
             var mock = BuildM3UMock(testTitle, new List<MediaItem>());
-            var subject = new Playlist(mock.Object);
+            var mockManager = new Mock<IFileManager>();
+
+            var song = new LocalSong("id", new SongPath("path"));
+            mockManager.Setup(x => x.GetSong(It.IsAny<MediaItem>())).Returns(song);
+            var service = new PlaylistServiceImpl(mockManager.Object);
+
+
+            var subject = new Playlist(service, mock.Object);
 
             subject.Save();
 
@@ -34,9 +41,8 @@ namespace MSOE.MediaComplete.Test.Playlists
             mockManager.Setup(x => x.GetSong(It.IsAny<MediaItem>())).Returns(song);
             var service = new PlaylistServiceImpl(mockManager.Object);
 
-            PlaylistService.SetService(service);
 
-            var subject = new Playlist(mock.Object);
+            var subject = new Playlist(service, mock.Object);
 
             subject.Save();
 
@@ -49,7 +55,14 @@ namespace MSOE.MediaComplete.Test.Playlists
         {
             const string testTitle = "Test title";
             var mock = BuildM3UMock(testTitle, new List<MediaItem> { BuildMediaItem(), BuildMediaItem() });
-            var subject = new Playlist(mock.Object);
+            var mockManager = new Mock<IFileManager>();
+
+            var song = new LocalSong("id", new SongPath("path"));
+            mockManager.Setup(x => x.GetSong(It.IsAny<MediaItem>())).Returns(song);
+            var service = new PlaylistServiceImpl(mockManager.Object);
+
+
+            var subject = new Playlist(service, mock.Object);
 
             subject.Delete();
 
@@ -68,8 +81,7 @@ namespace MSOE.MediaComplete.Test.Playlists
             mockManager.Setup(x => x.GetSong(It.IsAny<MediaItem>())).Returns(song);
             var service = new PlaylistServiceImpl(mockManager.Object);
 
-            PlaylistService.SetService(service);
-            var subject = new Playlist(mock.Object);
+            var subject = new Playlist(service, mock.Object);
 
             subject.Save();
             subject.Delete();
@@ -88,7 +100,14 @@ namespace MSOE.MediaComplete.Test.Playlists
 
             // ReSharper disable once UseObjectOrCollectionInitializer
             // Disabled since the set operation is the only thing we actually do with it.
-            var subject = new Playlist(mock.Object);
+            var mockManager = new Mock<IFileManager>();
+
+            var song = new LocalSong("id", new SongPath("path"));
+            mockManager.Setup(x => x.GetSong(It.IsAny<MediaItem>())).Returns(song);
+            var service = new PlaylistServiceImpl(mockManager.Object);
+
+
+            var subject = new Playlist(service, mock.Object);
 
             subject.Title = newTitle;
 
@@ -107,8 +126,7 @@ namespace MSOE.MediaComplete.Test.Playlists
             mockManager.Setup(x => x.GetSong(It.IsAny<MediaItem>())).Returns(song);
             var service = new PlaylistServiceImpl(mockManager.Object);
 
-            PlaylistService.SetService(service);
-            var subject = new Playlist(mock.Object);
+            var subject = new Playlist(service, mock.Object);
 
             subject.Save();
             subject.Title = newTitle;

--- a/MSOE.MediaComplete.Test/PollingTest.cs
+++ b/MSOE.MediaComplete.Test/PollingTest.cs
@@ -29,17 +29,18 @@ namespace MSOE.MediaComplete.Test
         [Timeout(40000)]
         public void CheckSubDirectoryPolling()
         {
+            var polling = new Polling();
             _dir = FileHelper.CreateDirectory(DirectoryPath+"/Subdir/Subdirdir");
             _file = FileHelper.CreateFile(_dir, Constants.FileTypes.ValidMp3);
 
             var pass = false;
             SettingWrapper.InboxDir = DirectoryPath;
-            Polling.Instance.TimeInMinutes = 0.0005;
+            polling.TimeInMinutes = 0.0005;
             Polling.InboxFilesDetected += delegate
             {
                 pass = true;
             };
-            Polling.Instance.Start();
+            polling.Start();
 
             while (!pass)
             {
@@ -56,17 +57,18 @@ namespace MSOE.MediaComplete.Test
         [Timeout(40000)]
         public void CheckForSongMp3()
         {
+            var polling = new Polling();
             _dir = FileHelper.CreateDirectory(DirectoryPath);
             _file = FileHelper.CreateFile(_dir, Constants.FileTypes.ValidMp3);
 
             var pass = false;
             SettingWrapper.InboxDir = DirectoryPath;
-            Polling.Instance.TimeInMinutes = 0.0005;
+            polling.TimeInMinutes = 0.0005;
             Polling.InboxFilesDetected += delegate
             {
                 pass = true;
             };
-            Polling.Instance.Start();
+            polling.Start();
 
             while (!pass)
             {
@@ -83,17 +85,18 @@ namespace MSOE.MediaComplete.Test
         [Timeout(40000)]//Milliseconds
         public void CheckForSongWma()
         {
+            var polling = new Polling();
             _dir = FileHelper.CreateDirectory(DirectoryPath);
             _file = FileHelper.CreateFile(_dir, Constants.FileTypes.ValidWma);
 
             var pass = false;
             SettingWrapper.InboxDir = DirectoryPath;
-            Polling.Instance.TimeInMinutes = 0.0005;
+            polling.TimeInMinutes = 0.0005;
             Polling.InboxFilesDetected += delegate
             {
                 pass = true;
             };
-            Polling.Instance.Start();
+            polling.Start();
 
             while (!pass)
             {
@@ -109,18 +112,19 @@ namespace MSOE.MediaComplete.Test
         [TestMethod]
         public void CheckForSongNotMusic()
         {
+            var polling = new Polling();
             _dir = FileHelper.CreateDirectory(DirectoryPath);
             _file = FileHelper.CreateFile(_dir, Constants.FileTypes.NonMusic);
 
             var pass = false;
             SettingWrapper.InboxDir = DirectoryPath;
 
-            Polling.Instance.TimeInMinutes = 0.0005;
+            polling.TimeInMinutes = 0.0005;
             Polling.InboxFilesDetected += delegate
             {
                 pass = true;
             };
-            Polling.Instance.Start();
+            polling.Start();
 
             Thread.Sleep(500);
 

--- a/MSOE.MediaComplete/InboxImportDialog.xaml.cs
+++ b/MSOE.MediaComplete/InboxImportDialog.xaml.cs
@@ -16,8 +16,9 @@ namespace MSOE.MediaComplete
     public partial class InboxImportDialog
     {
         private static IEnumerable<SongPath> _files;
+        private readonly IQueue _queue = Dependency.Resolve<IQueue>();
         private static InboxImportDialog _instance;
-        private IPolling _polling = Dependency.Resolve<IPolling>();
+        private readonly IPolling _polling = Dependency.Resolve<IPolling>();
 
         /// <summary>
         /// initializes the component
@@ -67,7 +68,7 @@ namespace MSOE.MediaComplete
             SettingWrapper.ShowInputDialog =!StopShowingCheckBox.IsChecked.GetValueOrDefault(false);
 
             //Do the move
-            Queue.Inst.Add(new Importer(Dependency.Resolve<IFileManager>(), _files, false));
+            _queue.Add(new Importer(Dependency.Resolve<IFileManager>(), _files, false));
 
             _polling.Reset();
             DialogResult = true;

--- a/MSOE.MediaComplete/InboxImportDialog.xaml.cs
+++ b/MSOE.MediaComplete/InboxImportDialog.xaml.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Windows;
 using MSOE.MediaComplete.Lib;
 using System;
+using Autofac;
 using MSOE.MediaComplete.Lib.Background;
 using MSOE.MediaComplete.Lib.Files;
 using MSOE.MediaComplete.Lib.Import;
@@ -65,7 +66,7 @@ namespace MSOE.MediaComplete
             SettingWrapper.ShowInputDialog =!StopShowingCheckBox.IsChecked.GetValueOrDefault(false);
 
             //Do the move
-            Queue.Inst.Add(new Importer(FileManager.Instance, _files, false));
+            Queue.Inst.Add(new Importer(Dependency.Resolve<IFileManager>(), _files, false));
             
 
             Polling.Instance.Reset();

--- a/MSOE.MediaComplete/InboxImportDialog.xaml.cs
+++ b/MSOE.MediaComplete/InboxImportDialog.xaml.cs
@@ -17,6 +17,7 @@ namespace MSOE.MediaComplete
     {
         private static IEnumerable<SongPath> _files;
         private static InboxImportDialog _instance;
+        private IPolling _polling = Dependency.Resolve<IPolling>();
 
         /// <summary>
         /// initializes the component
@@ -67,9 +68,8 @@ namespace MSOE.MediaComplete
 
             //Do the move
             Queue.Inst.Add(new Importer(Dependency.Resolve<IFileManager>(), _files, false));
-            
 
-            Polling.Instance.Reset();
+            _polling.Reset();
             DialogResult = true;
         }
 
@@ -81,7 +81,7 @@ namespace MSOE.MediaComplete
         private void CancelButton_OnClick(object sender, RoutedEventArgs e)
         {
             SettingWrapper.IsPolling = !StopShowingCheckBox.IsChecked.GetValueOrDefault((false));
-            Polling.Instance.Reset();
+            _polling.Reset();
             DialogResult = false;
             SettingWrapper.Save();
         }

--- a/MSOE.MediaComplete/MainWindow.xaml.cs
+++ b/MSOE.MediaComplete/MainWindow.xaml.cs
@@ -58,7 +58,9 @@ namespace MSOE.MediaComplete
         /// </summary>
         private readonly IFileManager _fileManager;
 
-        private readonly IPolling _polling;
+        private readonly IPolling _polling; 
+        private readonly IQueue _queue;
+
 
         #endregion
 
@@ -71,6 +73,7 @@ namespace MSOE.MediaComplete
             Dependency.BuildAsync();
             _fileManager = Dependency.Resolve<IFileManager>();
             _polling = Dependency.Resolve<IPolling>();
+            _queue = Dependency.Resolve<IQueue>();
             InitializeComponent();
             InitPlaylists();
             InitUi();
@@ -167,7 +170,7 @@ namespace MSOE.MediaComplete
                 using (var scope = Dependency.BeginLifetimeScope())
                 {
                     var importer = scope.Resolve<Importer>(new TypedParameter(typeof(IEnumerable<SongPath>), files), new TypedParameter(typeof(bool), move));
-                    Queue.Inst.Add(importer);
+                    _queue.Add(importer);
                 }
             }
             catch (DependencyResolutionException e)
@@ -217,7 +220,7 @@ namespace MSOE.MediaComplete
             using (var scope = Dependency.BeginLifetimeScope())
             {
                 var importer = scope.Resolve<Importer>(new TypedParameter(typeof(IEnumerable<SongPath>), files), new TypedParameter(typeof(bool), move));
-                Queue.Inst.Add(importer);
+                _queue.Add(importer);
             }
         }
 
@@ -228,7 +231,7 @@ namespace MSOE.MediaComplete
                 using (var scope = Dependency.BeginLifetimeScope())
                 {
                     var sorter = scope.Resolve<Sorter>(new TypedParameter(typeof(IEnumerable<SongPath>), results.NewFiles));
-                    Queue.Inst.Add(sorter);
+                    _queue.Add(sorter);
                 }
             }
         }
@@ -265,7 +268,7 @@ namespace MSOE.MediaComplete
 
                 if (result != MessageBoxResult.Yes) return;
 
-                Queue.Inst.Add(sorter);
+                _queue.Add(sorter);
             }
         }
 
@@ -278,7 +281,7 @@ namespace MSOE.MediaComplete
             using (var scope = Dependency.BeginLifetimeScope())
             {
                 var sorter = scope.Resolve<Sorter>(new TypedParameter(typeof (IEnumerable<SongPath>), files));
-                Queue.Inst.Add(sorter);
+                _queue.Add(sorter);
             }
         }
         #endregion
@@ -295,7 +298,7 @@ namespace MSOE.MediaComplete
             {
                 var files = SelectedSongs().Select(l => l.Data).OfType<LocalSong>().ToList();
                 var id = scope.Resolve<Identifier>(new TypedParameter(typeof(IEnumerable<LocalSong>), files));
-                Queue.Inst.Add(id);
+                _queue.Add(id);
             }
         }
 
@@ -310,7 +313,7 @@ namespace MSOE.MediaComplete
             {
                 var files = SelectedSongs().Select(l => l.Data).OfType<LocalSong>().ToList();
                 var id = scope.Resolve<Identifier>(new TypedParameter(typeof(IEnumerable<SongPath>), files));
-                Queue.Inst.Add(id);
+                _queue.Add(id);
             }
         }
 
@@ -577,7 +580,7 @@ namespace MSOE.MediaComplete
                 using (var scope = Dependency.BeginLifetimeScope())
                 {
                     var importer = scope.Resolve<Importer>(new TypedParameter(typeof(IEnumerable<SongPath>), files), new TypedParameter(typeof(bool), true));
-                    Queue.Inst.Add(importer);
+                    _queue.Add(importer);
                 }
             }
         }

--- a/MSOE.MediaComplete/MainWindow.xaml.cs
+++ b/MSOE.MediaComplete/MainWindow.xaml.cs
@@ -56,7 +56,9 @@ namespace MSOE.MediaComplete
         /// <summary>
         /// Private abstraction of the file system
         /// </summary>
-        private readonly IFileManager _fileManager = Dependency.Resolve<IFileManager>();
+        private readonly IFileManager _fileManager;
+
+        private readonly IPolling _polling;
 
         #endregion
 
@@ -67,6 +69,8 @@ namespace MSOE.MediaComplete
         public MainWindow()
         {
             Dependency.BuildAsync();
+            _fileManager = Dependency.Resolve<IFileManager>();
+            _polling = Dependency.Resolve<IPolling>();
             InitializeComponent();
             InitPlaylists();
             InitUi();
@@ -96,7 +100,7 @@ namespace MSOE.MediaComplete
             Logger.SetLogLevel(SettingWrapper.LogLevel);
             Polling.InboxFilesDetected += ImportFromInboxAsync;
             // ReSharper disable once UnusedVariable
-            var tmp = Polling.Instance;  // Run singleton constructor
+            var tmp = _polling;  // Run singleton constructor
             SettingWrapper.RaiseSettingEvent += Resort;
             SettingWrapper.RaiseSettingEvent += InitTreeView;
             Importer.ImportFinished += SortImports;

--- a/MSOE.MediaComplete/Settings.xaml.cs
+++ b/MSOE.MediaComplete/Settings.xaml.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Windows;
 using System.Windows.Forms;
+using Autofac;
 using MSOE.MediaComplete.Lib;
 using MSOE.MediaComplete.Lib.Logging;
 using MSOE.MediaComplete.Lib.Files;
@@ -26,7 +27,7 @@ namespace MSOE.MediaComplete
         private LayoutType _changedType;
         private bool _layoutHasChanged;
         private readonly List<string> _allDirs;
-        private readonly IFileManager _fileManager;
+        private readonly IFileManager _fileManager = Dependency.Resolve<IFileManager>();
         public Settings()
         {
             InitializeComponent();
@@ -41,7 +42,6 @@ namespace MSOE.MediaComplete
             Logger.SetLogLevel(SettingWrapper.LogLevel);
             MoveOrCopy.IsChecked = SettingWrapper.ShouldRemoveOnImport;
             _allDirs = SettingWrapper.AllDirectories;
-            _fileManager = FileManager.Instance;
             PollingCheckBoxChanged(CheckboxPolling, null);
             if (SettingWrapper.Layout.Equals(_layoutsDict[LayoutType.Pink]))
             {


### PR DESCRIPTION
- Autofac was moved from an initialized to its own class, where dependencies are resolved
- Classes in the main project call Dependency.cs in order to retrieve dependencies
- new instances of dependencies should not be initialized, but resolved from Dependency.
- Queue, Polling, FileManager, and some other nuisances are no longer singletons. This is not idiot proof. Don't be an idiot. Don't initialize new instances of things that shouldn't have multiple instances
- Some tests have been rewritten, this may come more heavy handedly later.
